### PR TITLE
Revert "Update ws dependency"

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,8 +25,7 @@
     "jest": "^26.6.3",
     "metro-react-native-babel-preset": "^0.64.0",
     "react-test-renderer": "17.0.1",
-    "typescript": "^3.8.3",
-    "ws": "^5.2.3"
+    "typescript": "^3.8.3"
   },
   "resolutions": {
     "@types/react": "^17"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6490,13 +6490,6 @@ ws@^1.1.0, ws@^1.1.5:
     options ">=0.0.5"
     ultron "1.0.x"
 
-ws@^5.2.3:
-  version "5.2.3"
-  resolved "https://registry.yarnpkg.com/ws/-/ws-5.2.3.tgz#05541053414921bc29c63bee14b8b0dd50b07b3d"
-  integrity sha512-jZArVERrMsKUatIdnLzqvcfydI85dvd/Fp1u/VOpfdDWQ4c9qWXe+VIeAbQ5FrDwciAkr+lzofXLz3Kuf26AOA==
-  dependencies:
-    async-limiter "~1.0.0"
-
 ws@^6.1.4:
   version "6.2.2"
   resolved "https://registry.yarnpkg.com/ws/-/ws-6.2.2.tgz#dd5cdbd57a9979916097652d78f1cc5faea0c32e"


### PR DESCRIPTION
Reverts taehoio/DesignSystem#2

still it's not fixed with react-native. https://github.com/facebook/react-native/issues/27396